### PR TITLE
Lexer bug fixes

### DIFF
--- a/src/input/PalexRuleLexer.cpp
+++ b/src/input/PalexRuleLexer.cpp
@@ -308,6 +308,7 @@ input::Token input::PalexRuleLexer::next_token() {
                 return this->try_restore_fallback(identifier, token_start);
         }
         identifier += this->cache.top();
+        this->curr_position.advance(this->cache.top());
         this->cache.pop();
         curr = this->get_char();
     }

--- a/src/lexer_generator/lexer_automaton.cpp
+++ b/src/lexer_generator/lexer_automaton.cpp
@@ -69,7 +69,6 @@ std::string lexer_generator::merge_states_by_priority(const std::map<std::string
     size_t highest_priority = 0;
     std::vector<std::string> hp_tokens;
 
-
     for (const std::string& token : to_merge) {
         if (!token.empty()) {
             const size_t token_priority = token_priorities.at(token);
@@ -100,17 +99,19 @@ lexer_generator::LexerAutomaton_t::StateID_t lexer_generator::insert_regex_ast_i
     const LexerAutomaton_t::StateID_t root_state, 
     const regex::RegexBase* const to_insert
 ) {
+    const LexerAutomaton_t::StateID_t regex_ast_entry_state = nfa.add_state("");
+    nfa.connect_states(root_state, regex_ast_entry_state); 
     if (dynamic_cast<const regex::RegexAlternation*>(to_insert)) {
-        return insert_regex_branch_in_nfa(nfa, root_state, dynamic_cast<const regex::RegexAlternation*>(to_insert));
+        return insert_regex_branch_in_nfa(nfa, regex_ast_entry_state, dynamic_cast<const regex::RegexAlternation*>(to_insert));
     } 
     if (dynamic_cast<const regex::RegexCharSet*>(to_insert)) {
-        return insert_regex_char_set_in_nfa(nfa, root_state, dynamic_cast<const regex::RegexCharSet*>(to_insert));
+        return insert_regex_char_set_in_nfa(nfa, regex_ast_entry_state, dynamic_cast<const regex::RegexCharSet*>(to_insert));
     }
     if (dynamic_cast<const regex::RegexQuantifier*>(to_insert)) {
-        return insert_regex_quantifier_in_nfa(nfa, root_state, dynamic_cast<const regex::RegexQuantifier*>(to_insert));
+        return insert_regex_quantifier_in_nfa(nfa, regex_ast_entry_state, dynamic_cast<const regex::RegexQuantifier*>(to_insert));
     }
     if (dynamic_cast<const regex::RegexSequence*>(to_insert)) {
-        return insert_regex_sequence_in_nfa(nfa, root_state, dynamic_cast<const regex::RegexSequence*>(to_insert));
+        return insert_regex_sequence_in_nfa(nfa, regex_ast_entry_state, dynamic_cast<const regex::RegexSequence*>(to_insert));
     }
 
     throw std::runtime_error("Tried to insert unknown regex type into NFA!");

--- a/src/regex/RegexParser.cpp
+++ b/src/regex/RegexParser.cpp
@@ -78,9 +78,6 @@ std::unique_ptr<regex::RegexBase> regex::RegexParser::parse_regex_sequence() {
         &RegexParser::parse_regex_quantifier
     );
 
-    if (sequence_content.empty()) {
-        this->throw_parsing_err("Empty sequences are not allowed, as they might lead to infinite matches!"); // TODO: allow this?
-    }
     if (sequence_content.size() == 1)  {
         return std::move(sequence_content.front());
     }

--- a/templates/cpp_lexer_source.template
+++ b/templates/cpp_lexer_source.template
@@ -41,6 +41,7 @@ bool %LEXER_NAMESPACE%::Token::is_ignored() const {
 %STATES%%ERROR_STATE%
         }
         identifier += this->cache.top();
+        this->curr_position.advance(this->cache.top());
         this->cache.pop();
         curr = this->get_char();
     }

--- a/tests/regex/regex_errors_test.cpp
+++ b/tests/regex/regex_errors_test.cpp
@@ -8,8 +8,7 @@
 
 int main() {
     const std::vector<std::u32string> TEST_CASES = {
-        U")", U"()", U"(", U"[",
-        U"", U"a|", U"|", U"|a",
+        U")", U"(", U"[",
         U"\\ca", U"\\uAfF", U"\\u24Ga", U"\\u{24fffag}", U"\\u{ffffffffff}",
         U"a{3,", U"a{3,", U"a{}", U"a{", U"a{3, 5}"
     };


### PR DESCRIPTION
- token positions are no longer incorrect
- empty sequences are now allowed
- fixed some inconclusive error messages caused be the two aspects above